### PR TITLE
Add relay_port to config

### DIFF
--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -17,14 +17,17 @@
     "boot": "auto",
     "ingress": true,
     "ports": {
-        "8080/tcp": 8080
+        "8080/tcp": 8080,
+        "7686/tcp": 7686
     },
     "ports_description": {
-        "8080/tcp": "otmonitor webserver port"
+        "8080/tcp": "otmonitor webserver port",
+        "7686/tcp": "otmonitor relay port (i.e. for OTGW integration)"
     },
     "options": {
         "otgw_host": "192.168.1.24",
         "otgw_port": 6638,
+        "relay_port": 7686,
         "mqtt_broker": "192.168.1.3",
         "mqtt_port": 1883,
         "mqtt_username": "mqtt",
@@ -34,6 +37,7 @@
     "schema": {
         "otgw_host": "str",
         "otgw_port": "int",
+        "relay_port": "int",
         "mqtt_broker": "str",
         "mqtt_port": "int",
         "mqtt_username": "str",

--- a/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
+++ b/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
@@ -22,7 +22,7 @@ mqtt {
 }
 server {
   enable true
-  port 7686
+  port %%relay_port%%
   relay true
 }
 clock {


### PR DESCRIPTION
Allow to change relay port of otmonitor and suggest user that it's possible to add/use HA's integrated OTGW integration together with this superb tool as a proxy for full diagnostics.