### PR TITLE
One more fix for relay_port and MQTT addon host

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ Example config for the add-on:
 ```yaml
 otgw_host: 192.168.1.26
 otgw_port: 6638
-mqtt_broker: 192.168.1.3
+relay_port: 7686
+mqtt_broker: addon_core_mosquitto
 mqtt_port: 1883
 mqtt_username: mqtt
 mqtt_password: PASSWORD_HERE
 ```
 
 Use with the [`climate.mqtt`](https://www.home-assistant.io/integrations/climate.mqtt/) integration.
+You can also connect HomeAssistant through [`opentherm_gw`](https://www.home-assistant.io/integrations/opentherm_gw/) integration using `relay_port`.
 
-Example `configuration.yaml` for Home Assistant
+Example `configuration.yaml` for Home Assistant:
 ```yaml
 climate:
   - platform: mqtt

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ mqtt_password: PASSWORD_HERE
 ```
 
 Use with the [`climate.mqtt`](https://www.home-assistant.io/integrations/climate.mqtt/) integration.
+
 You can also connect HomeAssistant through [`opentherm_gw`](https://www.home-assistant.io/integrations/opentherm_gw/) integration using `relay_port`.
 
 Example `configuration.yaml` for Home Assistant:

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -28,7 +28,7 @@
         "otgw_host": "192.168.1.24",
         "otgw_port": 6638,
         "relay_port": 7686,
-        "mqtt_broker": "192.168.1.3",
+        "mqtt_broker": "addon_core_mosquitto",
         "mqtt_port": 1883,
         "mqtt_username": "mqtt",
         "mqtt_password": "password_here"

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -10,6 +10,7 @@ OTMONITOR_CONF=/etc/otmonitor/otmonitor.conf
 
 otgw_host=$(bashio::config "otgw_host")
 otgw_port=$(bashio::config "otgw_port")
+relay_port=$(bashio::config "relay_port")
 mqtt_broker=$(bashio::config "mqtt_broker")
 mqtt_port=$(bashio::config "mqtt_port")
 mqtt_username=$(bashio::config "mqtt_username")
@@ -18,6 +19,7 @@ mqtt_password_base64=`echo -n $mqtt_password | base64 -w 0`
 
 sed -i "s/%%otgw_host%%/${otgw_host}/g" ${OTMONITOR_CONF}
 sed -i "s/%%otgw_port%%/${otgw_port}/g" ${OTMONITOR_CONF}
+sed -i "s/%%relay_port%%/${relay_port}/g" ${OTMONITOR_CONF}
 sed -i "s/%%mqtt_broker%%/${mqtt_broker}/g" ${OTMONITOR_CONF}
 sed -i "s/%%mqtt_port%%/${mqtt_port}/g" ${OTMONITOR_CONF}
 sed -i "s/%%mqtt_username%%/${mqtt_username}/g" ${OTMONITOR_CONF}


### PR DESCRIPTION
One file was missing relay_port edit.
Added HA's default MQTT broker address and to make it more popular, suggestion of possibility to use not only MQTT but OT integration too.