### PR TITLE
Add the option to do autoconfig for MQTT using the mosquitto addon

### DIFF
--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -31,7 +31,8 @@
         "mqtt_broker": "addon_core_mosquitto",
         "mqtt_port": 1883,
         "mqtt_username": "mqtt",
-        "mqtt_password": "password_here"
+        "mqtt_password": "password_here",
+        "mqtt_autoconfig": false
     },
     "panel_icon": "mdi:radiator",
     "schema": {
@@ -41,6 +42,7 @@
         "mqtt_broker": "str",
         "mqtt_port": "int",
         "mqtt_username": "str",
-        "mqtt_password": "str"
+        "mqtt_password": "str",
+        "mqtt_autoconfig": "bool"
     }
   }

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -40,10 +40,10 @@
         "otgw_host": "str",
         "otgw_port": "int",
         "relay_port": "int",
-        "mqtt_broker": "str",
-        "mqtt_port": "int",
-        "mqtt_username": "str",
-        "mqtt_password": "str",
+        "mqtt_broker": "str?",
+        "mqtt_port": "int?",
+        "mqtt_username": "str?",
+        "mqtt_password": "str?",
         "mqtt_autoconfig": "bool"
     }
   }

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -7,6 +7,7 @@
     "startup": "before",
     "hassio_api": true,
     "hassio_role": "default",
+    "services": ["mqtt:want"],
     "arch": [
         "aarch64",
         "amd64",

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -8,21 +8,34 @@ bashio::log.info "Initializing the config overwriting."
 
 OTMONITOR_CONF=/etc/otmonitor/otmonitor.conf
 
-otgw_host=$(bashio::config "otgw_host")
-otgw_port=$(bashio::config "otgw_port")
-relay_port=$(bashio::config "relay_port")
-mqtt_broker=$(bashio::config "mqtt_broker")
-mqtt_port=$(bashio::config "mqtt_port")
-mqtt_username=$(bashio::config "mqtt_username")
-mqtt_password=$(bashio::config "mqtt_password")
-mqtt_password_base64=`echo -n $mqtt_password | base64 -w 0`
+otgw_host="$( bashio::config 'otgw_host')"
+otgw_port="$( bashio::config 'otgw_port')"
+relay_port="$( bashio::config 'relay_port')"
 
-sed -i "s/%%otgw_host%%/${otgw_host}/g" ${OTMONITOR_CONF}
-sed -i "s/%%otgw_port%%/${otgw_port}/g" ${OTMONITOR_CONF}
-sed -i "s/%%relay_port%%/${relay_port}/g" ${OTMONITOR_CONF}
-sed -i "s/%%mqtt_broker%%/${mqtt_broker}/g" ${OTMONITOR_CONF}
-sed -i "s/%%mqtt_port%%/${mqtt_port}/g" ${OTMONITOR_CONF}
-sed -i "s/%%mqtt_username%%/${mqtt_username}/g" ${OTMONITOR_CONF}
-sed -i "s/%%mqtt_password%%/${mqtt_password_base64}/g" ${OTMONITOR_CONF}
+if bashio::config 'mqtt_autoconfig' ; then
+    bashio::log.info "Using autoconfig provided MQTT credentials from supervisor:"
+
+    mqtt_broker="$( bashio::services mqtt 'host' )"
+    mqtt_port="$( bashio::services mqtt 'port' )"
+    mqtt_username="$( bashio::services mqtt 'username' )"
+    mqtt_password="$( bashio::services mqtt 'password' )"
+else
+    bashio::log.info "Using manually p	rovided MQTT credentials"
+
+    mqtt_broker="$( bashio::config 'mqtt_broker' )"
+    mqtt_port="$( bashio::config 'mqtt_port' )"
+    mqtt_username="$( bashio::config 'mqtt_username' )"
+    mqtt_password="$( bashio::config 'mqtt_password' )"
+fi
+
+mqtt_password_base64="$( echo -n "${mqtt_password}" | base64 -w 0 )"
+
+sed -i "s|%%otgw_host%%|${otgw_host}|g" ${OTMONITOR_CONF}
+sed -i "s|%%otgw_port%%|${otgw_port}|g" ${OTMONITOR_CONF}
+sed -i "s|%%relay_port%%|${relay_port}|g" ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_broker%%|${mqtt_broker}|g" ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_port%%|${mqtt_port}|g" ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_username%%|${mqtt_username}|g" ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_password%%|${mqtt_password_base64}|g" ${OTMONITOR_CONF}
 
 bashio::log.info "Finished the config overwriting."

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -13,7 +13,7 @@ otgw_port="$( bashio::config 'otgw_port')"
 relay_port="$( bashio::config 'relay_port')"
 
 if bashio::config 'mqtt_autoconfig' ; then
-    bashio::log.info "Using autoconfig provided MQTT credentials from supervisor:"
+    bashio::log.info "Using autoconfig provided MQTT credentials from supervisor"
 
     mqtt_broker="$( bashio::services mqtt 'host' )"
     mqtt_port="$( bashio::services mqtt 'port' )"

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -20,7 +20,7 @@ if bashio::config 'mqtt_autoconfig' ; then
     mqtt_username="$( bashio::services mqtt 'username' )"
     mqtt_password="$( bashio::services mqtt 'password' )"
 else
-    bashio::log.info "Using manually p	rovided MQTT credentials"
+    bashio::log.info "Using manually provided MQTT credentials"
 
     mqtt_broker="$( bashio::config 'mqtt_broker' )"
     mqtt_port="$( bashio::config 'mqtt_port' )"


### PR DESCRIPTION
Hey Bas! 

I couldn't help myself, I'm having a vacation but I seem to have the urge to keep on devving :)

This PR adds the option for mqtt autoconfiguration to the addon. 

When users are using the mosquitto addon, the credentials that are generated and saved in the supervisor services api by the broker addon can be retrieved and used for connecting to the MQTT broker.

I will add another PR soon documenting all the added options in `DOCS.md` :) 

Let me know what you think :) 

(I need to do some additional testing prior to merge)