### PR TITLE
Add mechanism for custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,26 @@
 # [`otmonitor`](http://otgw.tclcode.com/otmonitor.html) Home Assistant supervisor add-on
 
-Install by going to Supervisor -> Add-on store -> Add new repository by url and fill in `https://github.com/basnijholt/addon-otmonitor`.
+## About
 
-Then install `otmonitor`.
+Opentherm monitor is a management and monitoring application for your [opentherm gateway](http://otgw.tclcode.com).
 
-Example config for the add-on:
-```yaml
-otgw_host: 192.168.1.26
-otgw_port: 6638
-relay_port: 7686
-mqtt_broker: addon_core_mosquitto
-mqtt_port: 1883
-mqtt_username: mqtt
-mqtt_password: PASSWORD_HERE
-```
 
-Use with the [`climate.mqtt`](https://www.home-assistant.io/integrations/climate.mqtt/) integration.
+## Local development
 
-You can also connect HomeAssistant through [`opentherm_gw`](https://www.home-assistant.io/integrations/opentherm_gw/) integration using `relay_port`.
+To locally test or develop on this addon, use vscode as explained in [the home assistant local adding testing developer documentation](https://developers.home-assistant.io/docs/add-ons/testing/).
 
-Example `configuration.yaml` for Home Assistant:
-```yaml
-climate:
-  - platform: mqtt
-    name: Thermostat
-    current_temperature_topic: events/central_heating/otmonitor/roomtemperature
-    temperature_command_topic: actions/otmonitor/setpoint
-    temperature_state_topic: events/central_heating/otmonitor/setpoint
-    min_temp: 5
-    max_temp: 35
-    initial: 17
-    temp_step: 0.5
-    precision: 0.5
-```
+It takes a while to build, download and start the local devcontainer as it runs a local home assistant instance using docker-in-docker (din), which is slow, but it's very useful to test your local changes.
+
+In short:
+
+- Install [Docker](https://docs.docker.com/install) on your local machine
+- Open the project in [Visual Studio Code](https://code.visualstudio.com/)
+- Copy the `.devcontainer` directory from the root of the community-addons repository
+- Select `Rebuild and Reopen in Container` from the command palette
+- Wait until the devcontainer itself is build
+- Start the ha instance by running task `Start Home Assistant`
+- Grab a coffee and wait until all the required home-assistant containers are up
+- Setup your local ha instance on http://localhost:812
+- Install mosquitto mqtt broker
+- Install the local otmonitor addon
+- Test your changes

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Opentherm monitor is a management and monitoring application for your [opentherm gateway](http://otgw.tclcode.com).
 
+## Installation
+
+Install by going to Supervisor -> Add-on store -> Add new repository by url and fill in `https://github.com/basnijholt/addon-otmonitor`.
+
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It takes a while to build, download and start the local devcontainer as it runs 
 In short:
 
 - Install [Docker](https://docs.docker.com/install) on your local machine
-- Open the project in [Visual Studio Code](https://code.visualstudio.com/)
 - Copy the `.devcontainer` directory from the root of the community-addons repository
+- Open the project in [Visual Studio Code](https://code.visualstudio.com/)
 - Select `Rebuild and Reopen in Container` from the command palette
 - Wait until the devcontainer itself is build
 - Start the ha instance by running task `Start Home Assistant`
@@ -24,3 +24,11 @@ In short:
 - Install mosquitto mqtt broker
 - Install the local otmonitor addon
 - Test your changes
+
+
+To build the container manually, use:
+
+```
+ARCH=amd64
+docker build --build-arg BUILD_FROM=homeassistant/${ARCH}-base-debian:buster  --build-arg BUILD_ARCH=${ARCH} .
+```

--- a/otmonitor/DOCS.md
+++ b/otmonitor/DOCS.md
@@ -95,3 +95,36 @@ Description: Retrieve the MQTT broker host, port and credentials from supervisor
 Default value: `false`
 Type: Boolean
 
+### Option: `html_templates.enabled`
+
+Description: Instead of the default layout, include the custom html templates that are provided with this plugin (Beta).
+Default value: `false`
+Type: Boolean
+
+### Option: `html_templates.editable`
+
+Description: Make the custom html templates edittable in `/share/otmonitor/html` (Beta).
+Default value: `false`
+Type: Boolean
+
+
+## Integration
+
+Use with the [`climate.mqtt`](https://www.home-assistant.io/integrations/climate.mqtt/) integration.
+
+You can also connect HomeAssistant through [`opentherm_gw`](https://www.home-assistant.io/integrations/opentherm_gw/) integration using `relay_port`.
+
+Example `configuration.yaml` for Home Assistant:
+```yaml
+climate:
+  - platform: mqtt
+    name: Thermostat
+    current_temperature_topic: events/central_heating/otmonitor/roomtemperature
+    temperature_command_topic: actions/otmonitor/setpoint
+    temperature_state_topic: events/central_heating/otmonitor/setpoint
+    min_temp: 5
+    max_temp: 35
+    initial: 17
+    temp_step: 0.5
+    precision: 0.5
+```

--- a/otmonitor/Dockerfile
+++ b/otmonitor/Dockerfile
@@ -4,17 +4,17 @@ ARG BUILD_REF
 ARG BUILD_VERSION
 ARG BUILD_FROM
 
+################################################################################
+## Stage 1: Build the otmonitor binary using the tcl/tk toolkit               ##
+################################################################################
 FROM ${BUILD_FROM} as builder
 ARG BUILD_ARCH
 
-
-SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "+x", "-c"]
 WORKDIR /otmonitor
+
 RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-         wget \
-         unzip \
- \
+ && apt-get install -y --no-install-recommends wget \
  && wget -qO /tmp/otm.tgz https://github.com/hvxl/otmonitor/archive/master.tar.gz \
  && tar xzf /tmp/otm.tgz --strip=1 -C . \
  && rm /tmp/otm.tgz \
@@ -31,6 +31,9 @@ RUN apt-get update \
  && ./tclkit sdx.kit wrap otmonitor -runtime runtime
 
 
+################################################################################
+## Stage 2: Build the addon container                                         ##
+################################################################################
 FROM ${BUILD_FROM}
 ARG BUILD_ARCH
 ARG BUILD_DATE
@@ -38,7 +41,7 @@ ARG BUILD_REF
 ARG BUILD_VERSION
 
 RUN apt-get update \
- && apt-get install -y \
+ && apt-get install -y --no-install-recommends \
         nginx \
         python3-tk \
         unzip \

--- a/otmonitor/Dockerfile
+++ b/otmonitor/Dockerfile
@@ -1,48 +1,61 @@
-ARG BUILD_FROM=hassioaddons/debian-base
-FROM ${BUILD_FROM}
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_REF
+ARG BUILD_VERSION
+ARG BUILD_FROM
 
+FROM ${BUILD_FROM} as builder
+ARG BUILD_ARCH
+
+
+SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
+WORKDIR /otmonitor
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        nginx \
-        wget \
-        python3-tk \
-    && rm -fr \
-        /tmp/* \
-        /etc/nginx \
-        /var/{cache,log}/* \
-        /var/lib/apt/lists/* \
-    \
-    && mkdir -p /var/log/nginx \
-    && touch /var/log/nginx/error.log
+ && apt-get install -y --no-install-recommends \
+         wget \
+         unzip \
+ \
+ && wget -qO /tmp/otm.tgz https://github.com/hvxl/otmonitor/archive/master.tar.gz \
+ && tar xzf /tmp/otm.tgz --strip=1 -C . \
+ && rm /tmp/otm.tgz \
+ && wget -qO ./sdx.kit https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/tclkit/sdx-20110317.kit \
+ \
+ && if [[ "${BUILD_ARCH}" = "aarch64" ]]; then URL_BASE="tclkit-aarch64"; fi \
+ && if [[ "${BUILD_ARCH}" = "amd64" ]]; then URL_BASE="tclkit-x64"; fi \
+ && if [[ "${BUILD_ARCH}" = "armhf" ]]; then URL_BASE="tclkit-ahf"; fi \
+ && if [[ "${BUILD_ARCH}" = "armv7" ]]; then URL_BASE="tclkit-ahf"; fi \
+ && if [[ "${BUILD_ARCH}" = "i386" ]]; then URL_BASE="tclkit"; fi \
+ && wget -qO tclkit http://otgw.tclcode.com/download/${URL_BASE} \
+ && cp tclkit runtime \
+ && chmod +x tclkit \
+ && ./tclkit sdx.kit wrap otmonitor -runtime runtime
 
-COPY rootfs /
 
-# Build arguments
-ARG BUILD_ARCH=amd64
+FROM ${BUILD_FROM}
+ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_REF
 ARG BUILD_VERSION
 
-RUN apt update && apt install wget unzip -y
-WORKDIR /tmp
-RUN wget https://github.com/hvxl/otmonitor/archive/master.zip && \
-    unzip master.zip && mv otmonitor-master /otmonitor
-WORKDIR /otmonitor
-RUN wget -O sdx.kit https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/tclkit/sdx-20110317.kit && \
-    if [[ "${BUILD_ARCH}" = "aarch64" ]]; then URL_BASE="tclkit-aarch64"; fi && \
-    if [[ "${BUILD_ARCH}" = "amd64" ]]; then URL_BASE="tclkit-x64"; fi && \
-    if [[ "${BUILD_ARCH}" = "armhf" ]]; then URL_BASE="tclkit-ahf"; fi && \
-    if [[ "${BUILD_ARCH}" = "armv7" ]]; then URL_BASE="tclkit-ahf"; fi && \
-    if [[ "${BUILD_ARCH}" = "i386" ]]; then URL_BASE="tclkit"; fi && \
-    wget -O tclkit http://otgw.tclcode.com/download/${URL_BASE} && \
-    cp tclkit runtime && \
-    chmod +x tclkit
+RUN apt-get update \
+ && apt-get install -y \
+        nginx \
+        python3-tk \
+        unzip \
+ && ln -sf /dev/stderr /var/log/nginx/error.log \
+ && ln -sf /dev/stdout /var/log/nginx/access.log \
+ && rm -fr \
+     /tmp/* \
+     /var/cache/* \
+     /var/lib/apt/lists/* \
+     /etc/nginx
 
-RUN ./tclkit sdx.kit wrap otmonitor -runtime runtime && \
-    cp otmonitor /opt/otmonitor && \
-    chmod +x /opt/otmonitor
+COPY rootfs /
 
-# Labels
+WORKDIR /opt
+COPY --from=builder /otmonitor/otmonitor .
+RUN chmod +x /opt/otmonitor
+
 LABEL \
     io.hass.name="otmonitor" \
     io.hass.description="otmonitor add-on" \
@@ -59,3 +72,4 @@ LABEL \
     org.label-schema.vcs-ref=${BUILD_REF} \
     org.label-schema.vcs-url="https://github.com/basnijholt/addon-otmonitor" \
     org.label-schema.vendor="Bas Nijholt"
+

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -25,6 +25,7 @@
         "8080/tcp": "otmonitor webserver port",
         "7686/tcp": "otmonitor relay port (i.e. for OTGW integration)"
     },
+    "map": ["share:rw"],
     "options": {
         "otgw_host": "192.168.1.24",
         "otgw_port": 6638,
@@ -33,7 +34,11 @@
         "mqtt_port": 1883,
         "mqtt_username": "mqtt",
         "mqtt_password": "password_here",
-        "mqtt_autoconfig": false
+        "mqtt_autoconfig": false,
+        "html_templates": {
+            "enabled": false,
+            "editable": false
+        }
     },
     "panel_icon": "mdi:radiator",
     "schema": {
@@ -45,6 +50,10 @@
         "mqtt_username": "str?",
         "mqtt_password": "str?",
         "mqtt_client_id": "str?",
-        "mqtt_autoconfig": "bool"
+        "mqtt_autoconfig": "bool",
+        "html_templates": {
+            "enabled": "bool",
+            "editable": "bool"
+        }
     }
-  }
+}

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -4,17 +4,43 @@
 # Handles configuration
 # ==============================================================================
 
-bashio::log.info "Initializing the config overwriting."
+bashio::log.info "Initializing service configuration."
 
 OTMONITOR_CONF=/etc/otmonitor/otmonitor.conf
+
+
+# ======================================
+# Configure custom html templates
+# ======================================
+
+if bashio::config.true 'html_templates.enabled'; then
+    bashio::log.info "Setting up html template files for otmonitor"
+
+    if bashio::config.true 'html_templates.editable' ; then
+        template_source=/share/otmonitor/html
+    else
+        template_source=/usr/share/otmonitor/html
+    fi
+
+    if ! bashio::fs.directory_exists "${template_source}" ; then
+        bashio::log.info "Copying html template files to ${template_source}"
+
+        mkdir -p "${template_source}"
+        cp -r /usr/share/otmonitor/html/* "${template_source}/"
+    fi
+
+    bashio::log.info "Copying the custom html templates to /opt/html"
+    ln -sf "${template_source}" /opt/html
+fi
+
 
 # ======================================
 # Update otgw host and ports in config
 # ======================================
 
-otgw_host="$( bashio::config 'otgw_host')"
-otgw_port="$( bashio::config 'otgw_port')"
-relay_port="$( bashio::config 'relay_port')"
+otgw_host="$( bashio::config 'otgw_host' )"
+otgw_port="$( bashio::config 'otgw_port' )"
+relay_port="$( bashio::config 'relay_port' )"
 
 sed -i "s|%%otgw_host%%|${otgw_host}|g" ${OTMONITOR_CONF}
 sed -i "s|%%otgw_port%%|${otgw_port}|g" ${OTMONITOR_CONF}


### PR DESCRIPTION
Hey @basnijholt 

I'm splitting the template feature it in two parts: First only the mechanism to make custom templates possible, leaving the templates directory for now as an empty dir, and in the other PR just the templates in a clean and tidy state. 

I need some more time to get the html templates theirselves working in an acceptable state, but I want to avoid the other MR getting way to big, I think it's already a lot without all the html templates.

So here stage 1: 
- A mechanism to allow custom templates to be used
- Documentation for this feature
- Some docker optimization that only copies the created binary from another layer, leaving all the build stuff behind to save some space and use the layered cache a bit more.

(I've removed the local devcontainer that I initially added by accident, left in because I thought it was useful, but now removed again as it's another 6 pages of text to review in a single PR: We can always add it later)
 