### PR TITLE
Fix configuration issue when mqtt_autoconfig is disabled (Fixes: #19)

### DIFF
--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -51,7 +51,7 @@ sed -i "s|%%relay_port%%|${relay_port}|g" ${OTMONITOR_CONF}
 # Update MQTT settings in config
 # ======================================
 
-if bashio::config 'mqtt_autoconfig' ; then
+if bashio::config.true 'mqtt_autoconfig' ; then
     bashio::log.info "Using autoconfig provided MQTT credentials from supervisor"
 
     mqtt_broker="$( bashio::services mqtt 'host' )"


### PR DESCRIPTION
I created a bug when autoconfiguration is supposed to be disabled but isn't: as a false value is set for `mqtt_autoconfig`, I should check for a truthy value rather than the variable being set in general.