### PR TITLE
Make MQTT topics and format configurable

### DIFF
--- a/otmonitor/DOCS.md
+++ b/otmonitor/DOCS.md
@@ -74,6 +74,12 @@ html_templates:
 
 ### Option: `mqtt`
 
+- Subkey: `autoconfig`
+  - Description: Retrieve the MQTT broker host, port and credentials from supervisor. (When using the mosquitto addon)
+  - This setting is required
+  - Default value: `false`
+  - Type: Boolean
+
 - Subkey: `broker`
   - Description: The host or ip to connect to the MQTT broker.
   - This setting is only required when `mqtt.autoconfig` is set to false.
@@ -103,12 +109,6 @@ html_templates:
   - This setting is required
   - Default value: `otmonitor`
   - Type: String
-
-- Subkey: `autoconfig`
-  - Description: Retrieve the MQTT broker host, port and credentials from supervisor. (For use with the mosquitto addon)
-  - This setting is required
-  - Default value: `false`
-  - Type: Boolean
 
 - Subkey: `action_topic`
   - Description: The topic for controlling the otgw over mqtt.

--- a/otmonitor/DOCS.md
+++ b/otmonitor/DOCS.md
@@ -16,7 +16,7 @@ that can be used for monitoring and managing your opentherm gateway.
 To get the addon running, some configuration needs to be updated prior to starting.
 
 This includes the host and port on which the addon can access your opentherm gateway and the
-credentials that the addon should use to connect to an MQTT broker (only required if `mqtt_autoconfig` is disabled, which is the default option).
+credentials that the addon should use to connect to an MQTT broker (only required if `mqtt.autoconfig` is disabled, which is the default option).
 
 This add-on has a couple of options available. To get the add-on running:
 
@@ -31,84 +31,111 @@ This add-on has a couple of options available. To get the add-on running:
 Add-on configuration:
 
 ```yaml
-otgw_host: 192.168.1.24
-otgw_port: 6638
-relay_port: 7686
-mqtt_broker: addon_core_mosquitto
-mqtt_port: 1883
-mqtt_username: mqtt
-mqtt_password: password_here
-mqtt_autoconfig: false
+otgw:
+  host: 192.168.1.24
+  port: 6638
+  relay_port: 7686
+
+mqtt:
+  autoconfig: false
+  broker: addon_core_mosquitto
+  port: 1883
+  username: mqtt
+  password: password_here
+  client_id: otmonitor
+  event_topic: "some/topic"
+  action_topic: "some/other/topic"
+
 html_templates:
   enabled: false
   editable: false
 ```
 
-### Option: `otgw_host`
+### Option: `otgw`
 
-Description: The host or ip to connect to the OTGW.
-Default value: `192.168.1.24`
-Type: String
+- Subkey: `host`
+  - Description: The host or ip to connect to the OTGW.
+  - This setting is required
+  - Default value: `192.168.1.24`
+  - Type: String
 
-### Option: `otgw_port`
+- Subkey: `port`
+  - Description: The port to connect to on the OTGW.
+  - This setting is required
+  - Default value: `6638`
+  - Type: Integer
 
-Description: The port to connect to on the OTGW.
-Default value: `6638`
-Type: Integer
+- Subkey: `relay_port`
+  - Description: The port for relaying opentherm messages.
+  - This setting is required
+  - Default value: `7686`
+  - Type: Integer
 
-### Option: `relay_port`
 
-Description: The port for relaying opentherm messages.
-Default value: `7686`
-Type: Integer
+### Option: `mqtt`
 
-### Option: `mqtt_broker`
+- Subkey: `broker`
+  - Description: The host or ip to connect to the MQTT broker.
+  - This setting is only required when `mqtt.autoconfig` is set to false.
+  - Default value: `addon_core_mosquitto`
+  - Type: String
 
-Description: The host or ip to connect to the MQTT broker.
-Default value: `addon_core_mosquitto`
-Type: String
+- Subkey: `port`
+  - Description: The port to connect to on the MQTT broker.
+  - This setting is only required when `mqtt.autoconfig` is set to false.
+  - Default value: `1883`
+  - Type: Integer
 
-### Option: `mqtt_port`
+- Subkey: `username`
+  - Description: The username for authenticating on the MQTT broker.
+  - This setting is only required when `mqtt.autoconfig` is set to false.
+  - Default value: `mqtt`
+  - Type: String
 
-Description: The port to connect to on the MQTT broker.
-Default value: `1883`
-Type: Integer
+- Subkey: `password`
+  - Description: The password for authenticating on the MQTT broker.
+  - This setting is only required when `mqtt.autoconfig` is set to false.
+  - Default value: `password_here`
+  - Type: String
 
-### Option: `mqtt_username`
+- Subkey: `client_id`
+  - Description: The client identifier for the mqtt connection
+  - This setting is required
+  - Default value: `otmonitor`
+  - Type: String
 
-Description: The username for authenticating on the MQTT broker.
-Default value: `mqtt`
-Type: String
+- Subkey: `autoconfig`
+  - Description: Retrieve the MQTT broker host, port and credentials from supervisor. (For use with the mosquitto addon)
+  - This setting is required
+  - Default value: `false`
+  - Type: Boolean
 
-### Option: `mqtt_password`
+- Subkey: `action_topic`
+  - Description: The topic for controlling the otgw over mqtt.
+  - This setting is required
+  - Default value: `events/central_heating/otmonitor`
+  - Type: String
 
-Description: The password for authenticating on the MQTT broker.
-Default value: `password_here`
-Type: String
+- Subkey: `event_topic`
+  - Description: The topic for receiving otgw events over mqtt.
+  - This setting is required
+  - Default value: `events/central_heating/otmonitor`
+  - Type: String
 
-### Option: `mqtt_client_id`
 
-Description: The client identifier for the mqtt connection
-Default value: `otmonitor`
-Type: String
+### Option: `html_templates` (Beta)
 
-### Option: `mqtt_autoconfig`
+- Subkey: `enabled`
+  - Description: Instead of the default layout, include the custom html templates that are provided with this plugin.
+  - This setting is required
+  - Default value: `false`
+  - Type: Boolean
 
-Description: Retrieve the MQTT broker host, port and credentials from supervisor. (For use with the mosquitto addon)
-Default value: `false`
-Type: Boolean
-
-### Option: `html_templates.enabled`
-
-Description: Instead of the default layout, include the custom html templates that are provided with this plugin (Beta).
-Default value: `false`
-Type: Boolean
-
-### Option: `html_templates.editable`
-
-Description: Make the custom html templates edittable in `/share/otmonitor/html` (Beta).
-Default value: `false`
-Type: Boolean
+- Subkey: `editable`
+  - Description: Make the custom html templates edittable in `/share/otmonitor/html`.
+  - This setting is required
+  - Default value: `false`
+  - Type: Boolean
 
 
 ## Integration

--- a/otmonitor/DOCS.md
+++ b/otmonitor/DOCS.md
@@ -43,8 +43,8 @@ mqtt:
   username: mqtt
   password: password_here
   client_id: otmonitor
-  event_topic: "some/topic"
-  action_topic: "some/other/topic"
+  event_topic: "events/central_heating/otmonitor"
+  action_topic: "actions/otmonitor"
 
 html_templates:
   enabled: false
@@ -113,7 +113,7 @@ html_templates:
 - Subkey: `action_topic`
   - Description: The topic for controlling the otgw over mqtt.
   - This setting is required
-  - Default value: `events/central_heating/otmonitor`
+  - Default value: `actions/otmonitor`
   - Type: String
 
 - Subkey: `event_topic`

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -31,7 +31,7 @@
             "host": "192.168.1.24",
             "port": 6638,
             "relay_port": 7686
-	},
+        },
         "mqtt": {
             "autoconfig": false,
             "broker": "addon_core_mosquitto",
@@ -40,7 +40,8 @@
             "password": "password_here",
             "client_id": "otmonitor",
             "action_topic": "actions/otmonitor",
-            "event_topic": "events/central_heating/otmonitor"
+            "event_topic": "events/central_heating/otmonitor",
+            "data_format": "raw"
         },
         "html_templates": {
             "enabled": false,
@@ -53,16 +54,17 @@
             "host": "str",
             "port": "int",
             "relay_port": "int"
-	},
+        },
         "mqtt": {
             "autoconfig": "bool",
             "broker": "str?",
             "port": "int?",
             "username": "str?",
             "password": "str?",
-            "client_id": "str?",
+            "client_id": "str",
             "action_topic": "str",
-            "event_topic": "str"
+            "event_topic": "str",
+            "data_format": "str"
         },
         "html_templates": {
             "enabled": "bool",

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -27,9 +27,11 @@
     },
     "map": ["share:rw"],
     "options": {
-        "otgw_host": "192.168.1.24",
-        "otgw_port": 6638,
-        "relay_port": 7686,
+        "otgw": {
+            "host": "192.168.1.24",
+            "port": 6638,
+            "relay_port": 7686
+	},
         "mqtt": {
             "autoconfig": false,
             "broker": "addon_core_mosquitto",
@@ -47,18 +49,20 @@
     },
     "panel_icon": "mdi:radiator",
     "schema": {
-        "otgw_host": "str",
-        "otgw_port": "int",
-        "relay_port": "int",
-        "mqtt_autoconfig": "bool",
+        "otgw": {
+            "host": "str",
+            "port": "int",
+            "relay_port": "int"
+	},
         "mqtt": {
+            "autoconfig": "bool",
             "broker": "str?",
             "port": "int?",
             "username": "str?",
             "password": "str?",
             "client_id": "str?",
-            "action_topic": "str?",
-            "event_topic": "str?"
+            "action_topic": "str",
+            "event_topic": "str"
         },
         "html_templates": {
             "enabled": "bool",

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -30,11 +30,16 @@
         "otgw_host": "192.168.1.24",
         "otgw_port": 6638,
         "relay_port": 7686,
-        "mqtt_broker": "addon_core_mosquitto",
-        "mqtt_port": 1883,
-        "mqtt_username": "mqtt",
-        "mqtt_password": "password_here",
-        "mqtt_autoconfig": false,
+        "mqtt": {
+            "autoconfig": false,
+            "broker": "addon_core_mosquitto",
+            "port": 1883,
+            "username": "mqtt",
+            "password": "password_here",
+            "client_id": "otmonitor",
+            "action_topic": "actions/otmonitor",
+            "event_topic": "events/central_heating/otmonitor"
+        },
         "html_templates": {
             "enabled": false,
             "editable": false
@@ -45,12 +50,16 @@
         "otgw_host": "str",
         "otgw_port": "int",
         "relay_port": "int",
-        "mqtt_broker": "str?",
-        "mqtt_port": "int?",
-        "mqtt_username": "str?",
-        "mqtt_password": "str?",
-        "mqtt_client_id": "str?",
         "mqtt_autoconfig": "bool",
+        "mqtt": {
+            "broker": "str?",
+            "port": "int?",
+            "username": "str?",
+            "password": "str?",
+            "client_id": "str?",
+            "action_topic": "str?",
+            "event_topic": "str?"
+        },
         "html_templates": {
             "enabled": "bool",
             "editable": "bool"

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -8,6 +8,16 @@ bashio::log.info "Initializing service configuration."
 
 OTMONITOR_CONF=/etc/otmonitor/otmonitor.conf
 
+# ======================================
+# Functions
+# ======================================
+
+function setconf() {
+    key="${2}"
+    value="${4}"
+
+    sed -i "s|%%${key}%%|${value}|g" ${OTMONITOR_CONF}
+}
 
 # ======================================
 # Configure custom html templates
@@ -38,46 +48,33 @@ fi
 # Update otgw host and ports in config
 # ======================================
 
-otgw_host="$( bashio::config 'otgw_host' )"
-otgw_port="$( bashio::config 'otgw_port' )"
-relay_port="$( bashio::config 'relay_port' )"
-
-sed -i "s|%%otgw_host%%|${otgw_host}|g"   ${OTMONITOR_CONF}
-sed -i "s|%%otgw_port%%|${otgw_port}|g"   ${OTMONITOR_CONF}
-sed -i "s|%%relay_port%%|${relay_port}|g" ${OTMONITOR_CONF}
-
+setconf --key otgw_host  --value "$( bashio::config otgw_host  )"
+setconf --key otgw_port  --value "$( bashio::config otgw_port  )"
+setconf --key relay_port --value "$( bashio::config relay_port )"
 
 # ======================================
 # Update MQTT settings in config
 # ======================================
 
+setconf --key mqtt_client_id    --value "$( bashio::config mqtt.client_id    )"
+setconf --key mqtt_action_topic --value "$( bashio::config mqtt.action_topic )"
+setconf --key mqtt_event_topic  --value "$( bashio::config mqtt.event_topic  )"
+
+
 if bashio::config.true 'mqtt.autoconfig' ; then
     bashio::log.info "Using autoconfig provided MQTT credentials from supervisor"
 
-    mqtt_broker="$( bashio::services mqtt 'host' )"
-    mqtt_port="$( bashio::services mqtt 'port' )"
-    mqtt_username="$( bashio::services mqtt 'username' )"
-    mqtt_password="$( bashio::services mqtt 'password' )"
+    setconf --key mqtt_broker   --value "$( bashio::services mqtt host     )"
+    setconf --key mqtt_port     --value "$( bashio::services mqtt port     )"
+    setconf --key mqtt_username --value "$( bashio::services mqtt username )"
+    setconf --key mqtt_password --value "$( bashio::services mqtt password | base64 -w 0 )"
 else
     bashio::log.info "Using manually provided MQTT credentials"
 
-    mqtt_broker="$( bashio::config 'mqtt.broker' )"
-    mqtt_port="$( bashio::config 'mqtt.port' )"
-    mqtt_username="$( bashio::config 'mqtt.username' )"
-    mqtt_password="$( bashio::config 'mqtt.password' )"
+    setconf --key mqtt_broker   --value "$( bashio::config mqtt.broker   )"
+    setconf --key mqtt_port     --value "$( bashio::config mqtt.port     )"
+    setconf --key mqtt_username --value "$( bashio::config mqtt.username )"
+    setconf --key mqtt_password --value "$( bashio::config mqtt.password | base64 -w 0 )"
 fi
-
-mqtt_client_id="$( bashio::config 'mqtt.client_id' )"
-mqtt_action_topic="$( bashio::config 'mqtt.action_topic' )"
-mqtt_event_topic="$( bashio::config 'mqtt.event_topic' )"
-mqtt_password_base64="$( echo -n "${mqtt_password}" | base64 -w 0 )"
-
-sed -i "s|%%mqtt_broker%%|${mqtt_broker}|g"             ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_port%%|${mqtt_port}|g"                 ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_username%%|${mqtt_username}|g"         ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_password%%|${mqtt_password_base64}|g"  ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_client_id%%|${mqtt_client_id}|g"       ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_event_topic%%|${mqtt_event_topic}|g"   ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_action_topic%%|${mqtt_action_topic}|g" ${OTMONITOR_CONF}
 
 bashio::log.info "Finished updating otmonitor config file."

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -48,9 +48,9 @@ fi
 # Update otgw host and ports in config
 # ======================================
 
-setconf --key otgw_host  --value "$( bashio::config otgw_host  )"
-setconf --key otgw_port  --value "$( bashio::config otgw_port  )"
-setconf --key relay_port --value "$( bashio::config relay_port )"
+setconf --key otgw_host  --value "$( bashio::config otgw.host       )"
+setconf --key otgw_port  --value "$( bashio::config otgw.port       )"
+setconf --key relay_port --value "$( bashio::config otgw.relay_port )"
 
 # ======================================
 # Update MQTT settings in config

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -42,8 +42,8 @@ otgw_host="$( bashio::config 'otgw_host' )"
 otgw_port="$( bashio::config 'otgw_port' )"
 relay_port="$( bashio::config 'relay_port' )"
 
-sed -i "s|%%otgw_host%%|${otgw_host}|g" ${OTMONITOR_CONF}
-sed -i "s|%%otgw_port%%|${otgw_port}|g" ${OTMONITOR_CONF}
+sed -i "s|%%otgw_host%%|${otgw_host}|g"   ${OTMONITOR_CONF}
+sed -i "s|%%otgw_port%%|${otgw_port}|g"   ${OTMONITOR_CONF}
 sed -i "s|%%relay_port%%|${relay_port}|g" ${OTMONITOR_CONF}
 
 
@@ -51,7 +51,7 @@ sed -i "s|%%relay_port%%|${relay_port}|g" ${OTMONITOR_CONF}
 # Update MQTT settings in config
 # ======================================
 
-if bashio::config.true 'mqtt_autoconfig' ; then
+if bashio::config.true 'mqtt.autoconfig' ; then
     bashio::log.info "Using autoconfig provided MQTT credentials from supervisor"
 
     mqtt_broker="$( bashio::services mqtt 'host' )"
@@ -61,22 +61,23 @@ if bashio::config.true 'mqtt_autoconfig' ; then
 else
     bashio::log.info "Using manually provided MQTT credentials"
 
-    mqtt_broker="$( bashio::config 'mqtt_broker' )"
-    mqtt_port="$( bashio::config 'mqtt_port' )"
-    mqtt_username="$( bashio::config 'mqtt_username' )"
-    mqtt_password="$( bashio::config 'mqtt_password' )"
+    mqtt_broker="$( bashio::config 'mqtt.broker' )"
+    mqtt_port="$( bashio::config 'mqtt.port' )"
+    mqtt_username="$( bashio::config 'mqtt.username' )"
+    mqtt_password="$( bashio::config 'mqtt.password' )"
 fi
 
+mqtt_client_id="$( bashio::config 'mqtt.client_id' )"
+mqtt_action_topic="$( bashio::config 'mqtt.action_topic' )"
+mqtt_event_topic="$( bashio::config 'mqtt.event_topic' )"
 mqtt_password_base64="$( echo -n "${mqtt_password}" | base64 -w 0 )"
-mqtt_client_id="$( bashio::config 'mqtt_client_id' )"
 
-if bashio::var.has_value "${mqtt_client_id}" ; then
-    sed -i "s|random_identifier_here|${mqtt_client_id:-'otmonitor'}|g" ${OTMONITOR_CONF}
-fi
+sed -i "s|%%mqtt_broker%%|${mqtt_broker}|g"             ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_port%%|${mqtt_port}|g"                 ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_username%%|${mqtt_username}|g"         ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_password%%|${mqtt_password_base64}|g"  ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_client_id%%|${mqtt_client_id}|g"       ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_event_topic%%|${mqtt_event_topic}|g"   ${OTMONITOR_CONF}
+sed -i "s|%%mqtt_action_topic%%|${mqtt_action_topic}|g" ${OTMONITOR_CONF}
 
-sed -i "s|%%mqtt_broker%%|${mqtt_broker}|g" ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_port%%|${mqtt_port}|g" ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_username%%|${mqtt_username}|g" ${OTMONITOR_CONF}
-sed -i "s|%%mqtt_password%%|${mqtt_password_base64}|g" ${OTMONITOR_CONF}
-
-bashio::log.info "Finished the config overwriting."
+bashio::log.info "Finished updating otmonitor config file."

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -59,7 +59,7 @@ setconf --key relay_port --value "$( bashio::config otgw.relay_port )"
 setconf --key mqtt_client_id    --value "$( bashio::config mqtt.client_id    )"
 setconf --key mqtt_action_topic --value "$( bashio::config mqtt.action_topic )"
 setconf --key mqtt_event_topic  --value "$( bashio::config mqtt.event_topic  )"
-
+setconf --key mqtt_data_format  --value "$( bashio::config mqtt.data_format  )"
 
 if bashio::config.true 'mqtt.autoconfig' ; then
     bashio::log.info "Using autoconfig provided MQTT credentials from supervisor"

--- a/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
+++ b/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
@@ -16,7 +16,6 @@ mqtt {
   username %%mqtt_username%%
   password %%mqtt_password%%
   devicetype central_heating
-  deviceid otmonitor
   format raw
   client %%mqtt_client_id%%
   eventtopic %%mqtt_event_topic%%

--- a/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
+++ b/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
@@ -18,7 +18,10 @@ mqtt {
   devicetype central_heating
   deviceid otmonitor
   format raw
-  client random_identifier_here
+  client %%mqtt_client_id%%
+  eventtopic %%mqtt_event_topic%%
+  actiontopic %%mqtt_action_topic%%
+
 }
 server {
   enable true

--- a/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
+++ b/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
@@ -21,7 +21,6 @@ mqtt {
   client %%mqtt_client_id%%
   eventtopic %%mqtt_event_topic%%
   actiontopic %%mqtt_action_topic%%
-
 }
 server {
   enable true

--- a/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
+++ b/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
@@ -15,8 +15,7 @@ mqtt {
   port %%mqtt_port%%
   username %%mqtt_username%%
   password %%mqtt_password%%
-  devicetype central_heating
-  format raw
+  format %%mqtt_data_format%%
   client %%mqtt_client_id%%
   eventtopic %%mqtt_event_topic%%
   actiontopic %%mqtt_action_topic%%


### PR DESCRIPTION
Hey Bas! :) 

I think i did it again: one of those PR's with many big changes for a few extra features..... 

What I've created: 
- I've changed the configuration into sections: one for `otgw`, one for `mqtt` and one for `html_templates` to prevent the configuration settings in the addon configuration from clogging up when adding more options.
- Removed the `deviceid` and `devicetype`: They are only used for forming the MQTT topics.
- Added the option to configure the MQTT topics instead, replacing the use of `deviceid` and `devicetype`. (And configured the old topics to be the default)
- Made the option to set the `client_id` for mqtt from the addon config required and removed the hidden default value I added earlier from the script.
- Added the option to set the mqtt format from the addon configuration (to allow use of json formats instead of raw)
- Added a little helper function to make updating the `otmonitor.conf` config file a bit more readable
- Updated the documentation to reflect the changes made

I've created separate commits for every item in the list so I can easily remove options if you don't think it's needed so let me know what you like :) 

(Next PR I'll try to keep it smaller to make it easier to review, sorry.... )