### PR TITLE
Update docs.md: Add data_format (Fixes: #24)

### DIFF
--- a/otmonitor/DOCS.md
+++ b/otmonitor/DOCS.md
@@ -45,6 +45,7 @@ mqtt:
   client_id: otmonitor
   event_topic: "events/central_heating/otmonitor"
   action_topic: "actions/otmonitor"
+  data_format: raw
 
 html_templates:
   enabled: false


### PR DESCRIPTION
This PR adds the missing `data_format` option to docs. 

