### PR TITLE
Update startup setting

### DIFF
--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -4,7 +4,7 @@
     "slug": "otmonitor",
     "description": "otmonitor add-on by Bas Nijholt",
     "url": "https://github.com/basnijholt/addon-otmonitor",
-    "startup": "before",
+    "startup": "services",
     "hassio_api": true,
     "hassio_role": "default",
     "services": ["mqtt:want"],


### PR DESCRIPTION
The startup arguments have changed:

> Default `application`. `initialize` will start add-on on setup of Home Assistant. `system` is for things like databases and not dependent on other things. `services` will start before Home Assistant, while application is started afterwards. Finally `once` is for applications that don't run as a daemon.

(Fixes: #27)