### PR TITLE
Update debian container to bullseye from the homeassistant dockerhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ To build the container manually, use:
 
 ```
 ARCH=amd64
-docker build --build-arg BUILD_FROM=homeassistant/${ARCH}-base-debian:buster  --build-arg BUILD_ARCH=${ARCH} .
+docker build --build-arg BUILD_FROM=homeassistant/${ARCH}-base-debian:bullseye --build-arg BUILD_ARCH=${ARCH} .
 ```

--- a/otmonitor/build.json
+++ b/otmonitor/build.json
@@ -1,11 +1,11 @@
 {
   "squash": false,
   "build_from": {
-    "aarch64": "hassioaddons/debian-base-aarch64:3.0.0",
-    "amd64": "hassioaddons/debian-base-amd64:3.0.0",
-    "armhf": "hassioaddons/debian-base-armhf:3.0.0",
-    "armv7": "hassioaddons/debian-base-armv7:3.0.0",
-    "i386": "hassioaddons/debian-base-i386:3.0.0"
+    "aarch64": "homeassistant/aarch64-base-debian:bullseye",
+    "amd64": "homeassistant/amd64-base-debian:bullseye",
+    "armhf": "homeassistant/armhf-base-debian:bullseye",
+    "armv7": "homeassistant/armv7-base-debian:bullseye",
+    "i386": "homeassistant/i386-base-debian:bullseye"
   },
   "args": {}
 }


### PR DESCRIPTION
Hey Bas! :) 

(I'll have to test this a bit more before merging, so let's not merge it yet....)


This commit updates the container used from buster to bullseye and uses the basecontainer used by homeassistant itself rather than the community container image.

I'll continue on this later this week after I've tested it on my own instance.