### PR TITLE
Fix "Expecting INT" error when rebuilding

### DIFF
--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -53,7 +53,7 @@
             "user": "user_here",
             "password": "password_here",
             "server": "mail_server_here",
-            "port": "mail_server_port_here",
+            "port": 25,
             "secure": "Plain, TLS or SSL"
         },
         "tspeak": {


### PR DESCRIPTION
The new mailserver config is expected to have the port as an integer. Because this is not the case, the container fails to start with the default settings