### PR TITLE
Remove incorrect string in email

### DIFF
--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -54,7 +54,7 @@
             "password": "password_here",
             "server": "mail_server_here",
             "port": "mail_server_port_here",
-            "secure": "Plain, TLS or SSL"
+            "secure": "Plain"
         },
         "tspeak": {
             "enable": false,


### PR DESCRIPTION
The secure string prevents the webserver from starting when used in the default settings. 

I will add this to the docs instead later this week :)