### PR TITLE
Update config.json

### DIFF
--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -17,6 +17,7 @@
     ],
     "boot": "auto",
     "ingress": true,
+    "init": false,
     "ports": {
         "8080/tcp": 8080,
         "7686/tcp": 7686


### PR DESCRIPTION
Fix error: ```s6-overlay-suexec: fatal: can only run as pid 1```

See also: https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/