### PR TITLE
Connection to serial device and optional MQTT

### DIFF
--- a/otmonitor/DOCS.md
+++ b/otmonitor/DOCS.md
@@ -16,7 +16,10 @@ that can be used for monitoring and managing your opentherm gateway.
 To get the addon running, some configuration needs to be updated prior to starting.
 
 This includes the host and port on which the addon can access your opentherm gateway and the
-credentials that the addon should use to connect to an MQTT broker (only required if `mqtt.autoconfig` is disabled, which is the default option).
+credentials that the addon should use to connect to an MQTT broker (only required if `mqtt.autoconfig` 
+is disabled, which is the default option). Also MQTT is not required if you plan to use the
+HomeAssistant OpenTherm integration through the relay port. In the latter case, set `mqtt.enable`
+to `false`.
 
 This add-on has a couple of options available. To get the add-on running:
 
@@ -54,17 +57,29 @@ html_templates:
 
 ### Option: `otgw`
 
+- Subkey: `type`
+  - Description: The connection type OTGW. OTGW supports either `tcp` or `serial`.
+  - This setting is required
+  - Default value: `tcp`
+  - Type: String
+
 - Subkey: `host`
   - Description: The host or ip to connect to the OTGW.
-  - This setting is required
+  - This setting is required if `type` is `tcp`.
   - Default value: `192.168.1.24`
   - Type: String
 
 - Subkey: `port`
   - Description: The port to connect to on the OTGW.
-  - This setting is required
+  - This setting is required if `type` is `tcp`.
   - Default value: `6638`
   - Type: Integer
+
+- Subkey: `device`
+  - Description: The serial device to use for connecting to the OTGW.
+  - This setting is required if `type` is `serial`.
+  - Default value: `/dev/serial0`
+  - Type: String
 
 - Subkey: `relay_port`
   - Description: The port for relaying opentherm messages.
@@ -74,6 +89,12 @@ html_templates:
 
 
 ### Option: `mqtt`
+
+- Subkey: `enable`
+  - Description: Enable the MQTT connection.
+  - This setting is required
+  - Default value: `true`
+  - Type: Boolean
 
 - Subkey: `autoconfig`
   - Description: Retrieve the MQTT broker host, port and credentials from supervisor. (When using the mosquitto addon)

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -16,6 +16,7 @@
         "i386"
     ],
     "boot": "auto",
+    "uart": true,
     "ingress": true,
     "init": false,
     "ports": {
@@ -29,8 +30,10 @@
     "map": ["share:rw"],
     "options": {
         "otgw": {
+            "type": "tcp",
             "host": "192.168.1.24",
             "port": 6638,
+            "device": "/dev/serial0",
             "relay_port": 7686
         },
         "mqtt": {
@@ -71,8 +74,10 @@
     "panel_icon": "mdi:radiator",
     "schema": {
         "otgw": {
-            "host": "str",
-            "port": "int",
+            "type": "str",
+            "host": "str?",
+            "port": "int?",
+            "device": "str?",
             "relay_port": "int"
         },
         "mqtt": {

--- a/otmonitor/config.json
+++ b/otmonitor/config.json
@@ -37,6 +37,7 @@
             "relay_port": 7686
         },
         "mqtt": {
+            "enable": true,
             "autoconfig": false,
             "broker": "addon_core_mosquitto",
             "port": 1883,
@@ -81,6 +82,7 @@
             "relay_port": "int"
         },
         "mqtt": {
+            "enable": "bool",
             "autoconfig": "bool",
             "broker": "str?",
             "port": "int?",

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -48,9 +48,11 @@ fi
 # Update otgw host and ports in config
 # ======================================
 
-setconf --key otgw_host  --value "$( bashio::config otgw.host       )"
-setconf --key otgw_port  --value "$( bashio::config otgw.port       )"
-setconf --key relay_port --value "$( bashio::config otgw.relay_port )"
+setconf --key otgw_type   --value "$( bashio::config otgw.type       )"
+setconf --key otgw_host   --value "$( bashio::config otgw.host       )"
+setconf --key otgw_port   --value "$( bashio::config otgw.port       )"
+setconf --key otgw_device --value "$( bashio::config otgw.device     )"
+setconf --key relay_port  --value "$( bashio::config otgw.relay_port )"
 
 # ======================================
 # Update MQTT settings in config

--- a/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
+++ b/otmonitor/rootfs/etc/cont-init.d/otmonitor.sh
@@ -58,6 +58,7 @@ setconf --key relay_port  --value "$( bashio::config otgw.relay_port )"
 # Update MQTT settings in config
 # ======================================
 
+setconf --key mqtt_enable       --value "$( bashio::config mqtt.enable       )"
 setconf --key mqtt_client_id    --value "$( bashio::config mqtt.client_id    )"
 setconf --key mqtt_action_topic --value "$( bashio::config mqtt.action_topic )"
 setconf --key mqtt_event_topic  --value "$( bashio::config mqtt.event_topic  )"

--- a/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
+++ b/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
@@ -11,7 +11,7 @@ connection {
   device %%otgw_device%%
 }
 mqtt {
-  enable true
+  enable %%mqtt_enable%%
   broker %%mqtt_broker%%
   port %%mqtt_port%%
   username %%mqtt_username%%

--- a/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
+++ b/otmonitor/rootfs/etc/otmonitor/otmonitor.conf
@@ -5,9 +5,10 @@ web {
 }
 connection {
   enable true
-  type tcp
+  type %%otgw_type%%
   host %%otgw_host%%
   port %%otgw_port%%
+  device %%otgw_device%%
 }
 mqtt {
   enable true


### PR DESCRIPTION
This PR adds the following to the addon:
* Connection over serial port, as also requested in #40.
* Option to disable MQTT, which is not necessary if the OpenTherm integration of Home Assistant is used.

New configuration options (and docs) are added:
* `otgw`
  - `type`: Can be either `tcp` or `serial`. The default is `tcp`.
  - `device`: To be set if the serial device is used, ignored otherwise.
* `mqtt`
  - `enable`: Can be `true` or `false`. Default is `true` for being consistent with current behavior.
